### PR TITLE
Fix concurrency issues in logz module

### DIFF
--- a/cmd/cli/cmds_logz.go
+++ b/cmd/cli/cmds_logz.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -32,7 +33,8 @@ func LogzCmds() []*cobra.Command {
 func newLogCmd(level string, aliases []string) *cobra.Command {
 	var metaData, ctx map[string]string
 	var msg, output, format string
-	
+	var mu sync.RWMutex
+
 	cmd := &cobra.Command{
 		Use:     level,
 		Aliases: aliases,
@@ -69,6 +71,8 @@ func newLogCmd(level string, aliases []string) *cobra.Command {
 			ctxInterface := make(map[string]interface{})
 			for k, v := range ctx {
 				ctxInterface[k] = v
+				mu.Lock()
+				defer mu.Unlock()
 			}
 			switch level {
 			case "debug":
@@ -98,6 +102,8 @@ func newLogCmd(level string, aliases []string) *cobra.Command {
 
 // rotateLogsCmd allows manual log rotation.
 func rotateLogsCmd() *cobra.Command {
+	var mu sync.RWMutex
+
 	return &cobra.Command{
 		Use: "rotate",
 		Annotations: GetDescriptions(
@@ -105,6 +111,9 @@ func rotateLogsCmd() *cobra.Command {
 			false,
 		),
 		Run: func(cmd *cobra.Command, args []string) {
+			mu.Lock()
+			defer mu.Unlock()
+
 			configManager := logger.NewConfigManager()
 			if configManager == nil {
 				fmt.Println("Error initializing ConfigManager.")
@@ -130,6 +139,8 @@ func rotateLogsCmd() *cobra.Command {
 
 // checkLogSizeCmd checks the current log size.
 func checkLogSizeCmd() *cobra.Command {
+	var mu sync.RWMutex
+
 	return &cobra.Command{
 		Use: "check-size",
 		Annotations: GetDescriptions(
@@ -137,6 +148,9 @@ func checkLogSizeCmd() *cobra.Command {
 			false,
 		),
 		Run: func(cmd *cobra.Command, args []string) {
+			mu.Lock()
+			defer mu.Unlock()
+
 			configManager := logger.NewConfigManager()
 			if configManager == nil {
 				fmt.Println("Error initializing ConfigManager.")
@@ -164,6 +178,8 @@ func checkLogSizeCmd() *cobra.Command {
 
 // archiveLogsCmd allows manual log archiving.
 func archiveLogsCmd() *cobra.Command {
+	var mu sync.RWMutex
+
 	return &cobra.Command{
 		Use: "archive",
 		Annotations: GetDescriptions(
@@ -171,6 +187,9 @@ func archiveLogsCmd() *cobra.Command {
 			false,
 		),
 		Run: func(cmd *cobra.Command, args []string) {
+			mu.Lock()
+			defer mu.Unlock()
+
 			err := logger.ArchiveLogs(nil)
 			if err != nil {
 				fmt.Printf("Error archiving logs: %v\n", err)
@@ -183,6 +202,8 @@ func archiveLogsCmd() *cobra.Command {
 
 // watchLogsCmd monitors logs in real-time.
 func watchLogsCmd() *cobra.Command {
+	var mu sync.RWMutex
+
 	return &cobra.Command{
 		Use:     "watch",
 		Aliases: []string{"w"},
@@ -191,6 +212,9 @@ func watchLogsCmd() *cobra.Command {
 			false,
 		),
 		Run: func(cmd *cobra.Command, args []string) {
+			mu.Lock()
+			defer mu.Unlock()
+
 			configManager := logger.NewConfigManager()
 			if configManager == nil {
 				fmt.Println("Error initializing ConfigManager.")

--- a/cmd/cli/cmds_metrics.go
+++ b/cmd/cli/cmds_metrics.go
@@ -5,6 +5,7 @@ import (
 	"github.com/faelmori/logz/internal/logger"
 	"github.com/spf13/cobra"
 	"strconv"
+	"sync"
 	"time"
 )
 
@@ -31,11 +32,16 @@ func MetricsCmd() *cobra.Command {
 // enableMetricsCmd creates the command to enable Prometheus integration.
 func enableMetricsCmd() *cobra.Command {
 	var port string
+	var mu sync.RWMutex
+
 	enMCmd := &cobra.Command{
 		Use:     "enable",
 		Aliases: []string{"en"},
 		Short:   "Enable Prometheus integration",
 		Run: func(cmd *cobra.Command, args []string) {
+			mu.Lock()
+			defer mu.Unlock()
+
 			pm := logger.GetPrometheusManager()
 			pm.Enable(port)
 		},
@@ -46,11 +52,16 @@ func enableMetricsCmd() *cobra.Command {
 
 // disableMetricsCmd creates the command to disable Prometheus integration.
 func disableMetricsCmd() *cobra.Command {
+	var mu sync.RWMutex
+
 	return &cobra.Command{
 		Use:     "disable",
 		Aliases: []string{"dis"},
 		Short:   "Disable Prometheus integration",
 		Run: func(cmd *cobra.Command, args []string) {
+			mu.Lock()
+			defer mu.Unlock()
+
 			pm := logger.GetPrometheusManager()
 			pm.Disable()
 		},
@@ -59,12 +70,17 @@ func disableMetricsCmd() *cobra.Command {
 
 // addMetricCmd creates the command to add or update a Prometheus metric.
 func addMetricCmd() *cobra.Command {
+	var mu sync.RWMutex
+
 	return &cobra.Command{
 		Use:     "add [name] [value]",
 		Aliases: []string{"a"},
 		Short:   "Add or update a Prometheus metric",
 		Args:    cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
+			mu.Lock()
+			defer mu.Unlock()
+
 			name := args[0]
 			value, valueErr := strconv.ParseFloat(args[1], 64)
 			if valueErr != nil {
@@ -79,12 +95,17 @@ func addMetricCmd() *cobra.Command {
 
 // removeMetricCmd creates the command to remove a Prometheus metric.
 func removeMetricCmd() *cobra.Command {
+	var mu sync.RWMutex
+
 	return &cobra.Command{
 		Use:     "remove [name]",
 		Aliases: []string{"r"},
 		Short:   "Remove a Prometheus metric",
 		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			mu.Lock()
+			defer mu.Unlock()
+
 			name := args[0]
 			pm := logger.GetPrometheusManager()
 			pm.RemoveMetric(name)
@@ -94,11 +115,16 @@ func removeMetricCmd() *cobra.Command {
 
 // listMetricsCmd creates the command to list all Prometheus metrics.
 func listMetricsCmd() *cobra.Command {
+	var mu sync.RWMutex
+
 	return &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"l"},
 		Short:   "List all Prometheus metrics",
 		Run: func(cmd *cobra.Command, args []string) {
+			mu.RLock()
+			defer mu.RUnlock()
+
 			pm := logger.GetPrometheusManager()
 			metrics := pm.GetMetrics()
 			if len(metrics) == 0 {


### PR DESCRIPTION
Refactor the logz module to handle concurrency and simultaneous access to configuration and attributes.

* **Concurrency Handling**:
  - Add `sync.RWMutex` to `LogzCoreImpl`, `ConfigManagerImpl`, and `NotifierManagerImpl` to handle concurrent access.
  - Protect access to `metadata`, `config`, and `notifiers` fields using `RWMutex`.
  - Update methods in `internal/logger/logger.go`, `internal/logger/config.go`, and `internal/logger/notifier_manager.go` to use `Lock`, `Unlock`, `RLock`, and `RUnlock` for read and write access.

* **CLI Commands**:
  - Add `sync.RWMutex` to various functions in `cmd/cli/cmds_logz.go` and `cmd/cli/cmds_metrics.go` to handle concurrent access.
  - Update `newLogCmd`, `rotateLogsCmd`, `checkLogSizeCmd`, `archiveLogsCmd`, and `watchLogsCmd` in `cmd/cli/cmds_logz.go` to use the updated logger with concurrency handling.
  - Update `enableMetricsCmd`, `disableMetricsCmd`, `addMetricCmd`, `removeMetricCmd`, and `listMetricsCmd` in `cmd/cli/cmds_metrics.go` to use the updated logger with concurrency handling.

* **Service Management**:
  - Add `sync.RWMutex` to `internal/logger/service.go` to handle concurrent access to service management.
  - Protect access to global logger using `RWMutex`.
  - Update `Run`, `Start`, `Stop`, and `initializeGlobalLogger` methods to use `Lock` and `Unlock` for write access.

